### PR TITLE
Fix example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Special thanks to scriptures.nephi.org for the lds-scriptures.json that was uplo
 
 Pseudo-preview any PR here (just swap out `bryanwhiting-patch-1` for your branch):
 
-https://htmlpreview.github.io/?https://github.com/readscriptures/readscriptures.github.io/blob/bryanwhiting-patch-1/index.html 
+https://htmlpreview.github.io/?https://github.com/scripturestudy/scripturestudy.github.io/blob/bryanwhiting-patch-1/index.html


### PR DESCRIPTION
## Summary
- update the README link to point at `scripturestudy.github.io`

## Testing
- `true`