### PR TITLE
Add JSON validity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Special thanks to scriptures.nephi.org for the lds-scriptures.json that was uplo
 Pseudo-preview any PR here (just swap out `bryanwhiting-patch-1` for your branch):
 
 https://htmlpreview.github.io/?https://github.com/readscriptures/readscriptures.github.io/blob/bryanwhiting-patch-1/index.html 
+
+## Running Tests
+
+After installing [Node.js](https://nodejs.org/), run:
+
+```bash
+npm test
+```
+
+This executes `node tests/test_json_validity.js` which verifies that
+`lds-scriptures.json` is valid JSON and contains the expected keys.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "scripturestudy",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/test_json_validity.js"
+  }
+}

--- a/tests/test_json_validity.js
+++ b/tests/test_json_validity.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const jsonPath = 'lds-scriptures.json';
+const raw = fs.readFileSync(jsonPath, 'utf8');
+let data;
+try {
+  data = JSON.parse(raw);
+} catch (err) {
+  console.error('Failed to parse', jsonPath);
+  throw err;
+}
+
+assert(Array.isArray(data), 'Root JSON element should be an array');
+assert(data.length > 0, 'JSON array should not be empty');
+
+const sample = data[0];
+const expectedKeys = [
+  'volume_title',
+  'book_title',
+  'book_short_title',
+  'chapter_number',
+  'verse_number',
+  'verse_title',
+  'verse_short_title',
+  'scripture_text'
+];
+
+for (const key of expectedKeys) {
+  assert(key in sample, `Missing key: ${key}`);
+}
+
+console.log('JSON is valid with expected keys.');


### PR DESCRIPTION
## Summary
- add a small Node test to verify `lds-scriptures.json`
- expose the test via `npm test`
- document how to run the test in the README
- rename package name to `scripturestudy`

## Testing
- `npm test`
