### PR TITLE
Fix CFM week selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -1745,6 +1745,8 @@
             const currentWeek = cfmSchedule.findIndex(week => {
                 const start = new Date(week.start_date);
                 const end = new Date(week.end_date);
+                // include the entire end date so selection works late on the last day
+                end.setHours(23, 59, 59, 999);
                 return today >= start && today <= end;
             });
             


### PR DESCRIPTION
## Summary
- ensure the CFM selector includes the last day of the week when detecting the current week

## Testing
- `npm test`
