### PR TITLE
Add highlight actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,6 +690,45 @@
             </div>
         </div>
 
+        <!-- Actions for highlighted text -->
+        <div id="textSelectionModal" class="modal-overlay">
+            <div class="modal-box w-full max-w-md">
+                <button id="textSelectionModalCloseButton" class="modal-close-button">&times;</button>
+                <h3 class="text-lg font-semibold mb-1 text-gray-800">Selected Text Actions</h3>
+                <p id="textSelectionDisplay" class="text-sm text-gray-500 mb-4 break-words"></p>
+                <div class="space-y-2">
+                    <button id="selectionCopyButton"
+                        class="w-full flex items-center space-x-2 p-3 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+                        </svg>
+                        <span>Copy Text</span>
+                    </button>
+                    <button id="selectionAddToJournalButton"
+                        class="w-full flex items-center space-x-2 p-3 bg-green-500 text-white rounded hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                        </svg>
+                        <span>Add to Journal</span>
+                    </button>
+                    <button id="selectionSearchButton"
+                        class="w-full flex items-center space-x-2 p-3 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                        </svg>
+                        <span>Search</span>
+                    </button>
+                    <button id="selectionGoogleSearchButton"
+                        class="w-full flex items-center space-x-2 p-3 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                        </svg>
+                        <span>Search on Google</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+
     </div> <!-- End of .container -->
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -109,6 +109,15 @@
         const compactActionGoogleSearchButton = document.getElementById("compactActionGoogleSearchButton");
         const compactActionChurchSiteLink = document.getElementById("compactActionChurchSiteLink");
 
+        // Modal for selected text actions
+        const textSelectionModal = document.getElementById('textSelectionModal');
+        const textSelectionModalCloseButton = document.getElementById('textSelectionModalCloseButton');
+        const textSelectionDisplay = document.getElementById('textSelectionDisplay');
+        const selectionCopyButton = document.getElementById('selectionCopyButton');
+        const selectionAddToJournalButton = document.getElementById('selectionAddToJournalButton');
+        const selectionSearchButton = document.getElementById('selectionSearchButton');
+        const selectionGoogleSearchButton = document.getElementById('selectionGoogleSearchButton');
+
         // Journal DOM Elements
         const journalEditor = document.getElementById("journalEditor");
         const journalPreview = document.getElementById("journalPreview");
@@ -218,6 +227,47 @@
             } else {
                 console.error("noteModal hideModal: noteModal element not found!");
             }
+        }
+
+        function openNoteModalForText(text, title, feedbackButton) {
+            if (!noteModal) return;
+            if (modalScriptureTextEl) modalScriptureTextEl.textContent = text;
+            if (modalVerseTitleEl) modalVerseTitleEl.textContent = title;
+
+            const handleSave = () => {
+                const userNote = noteTextarea.value.trim();
+                let appended = `> ${text} (${title})`;
+                if (userNote) appended = `${userNote}\n${appended}`;
+                if (journalEditor.value) appended = `\n\n${appended}`;
+                journalEditor.value += appended;
+                updateJournalPreview();
+                journalEditor.scrollTop = journalEditor.scrollHeight;
+                if (feedbackButton) showButtonFeedback(feedbackButton, '<span class="text-green-600">✓ Added!</span>');
+                cleanup();
+                hideModal();
+            };
+
+            const handleCancel = () => { cleanup(); hideModal(); };
+
+            const handleKey = (e) => { if (e.key === 'Enter' && e.shiftKey) { e.preventDefault(); handleSave(); } };
+
+            const cleanup = () => {
+                noteTextarea.removeEventListener('keydown', handleKey);
+                saveNoteButton.removeEventListener('click', handleSave);
+                cancelNoteButton.removeEventListener('click', handleCancel);
+                if (modalCloseButton) modalCloseButton.removeEventListener('click', handleCancel);
+                noteModal.removeEventListener('click', overlayClick);
+            };
+
+            const overlayClick = (e) => { if (e.target === noteModal) handleCancel(); };
+
+            noteTextarea.addEventListener('keydown', handleKey);
+            saveNoteButton.addEventListener('click', handleSave, {once: true});
+            cancelNoteButton.addEventListener('click', handleCancel, {once: true});
+            if (modalCloseButton) modalCloseButton.addEventListener('click', handleCancel, {once: true});
+            noteModal.addEventListener('click', overlayClick);
+
+            showModal();
         }
 
         // --- Data Fetching and Initialization ---
@@ -2077,5 +2127,83 @@
             compactActionChurchSiteLink.addEventListener('click', () => {
                 // Allow a moment for the new tab to open before closing.
                 setTimeout(() => closeModal(compactActionModal), 100);
+            });
+        }
+
+        // --- Highlighted Text Actions ---
+        let currentSelectedText = '';
+
+        function showTextSelectionModal(text) {
+            currentSelectedText = text;
+            if (textSelectionDisplay) textSelectionDisplay.textContent = text;
+            openModal(textSelectionModal);
+        }
+
+       function handleSelectionEvent() {
+           const selection = window.getSelection();
+           if (!selection || !selection.toString().trim()) return;
+           const text = selection.toString().trim();
+           const anchor = selection.anchorNode;
+           if (!anchor) return;
+           if (!resultsContainer.contains(anchor) && !contextDrawerContent.contains(anchor)) return;
+            // Clear the current selection so clicks on the modal won't retrigger
+            // a new selection event or accidentally select modal text
+            try {
+                selection.removeAllRanges();
+            } catch (err) {
+                console.warn('Failed to clear text selection:', err);
+            }
+           showTextSelectionModal(text);
+       }
+
+        document.addEventListener('mouseup', handleSelectionEvent);
+        document.addEventListener('touchend', handleSelectionEvent);
+
+        if (textSelectionModalCloseButton) {
+            textSelectionModalCloseButton.addEventListener('click', () => closeModal(textSelectionModal));
+        }
+
+        if (textSelectionModal) {
+            textSelectionModal.addEventListener('click', (e) => { if (e.target === textSelectionModal) closeModal(textSelectionModal); });
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && textSelectionModal.classList.contains('active')) {
+                closeModal(textSelectionModal);
+            }
+        });
+
+        if (selectionCopyButton) {
+            selectionCopyButton.addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(currentSelectedText);
+                    showButtonFeedback(selectionCopyButton, '<span class="text-green-600">✓ Copied!</span>');
+                } catch (err) {
+                    console.error('Failed to copy text:', err);
+                    showButtonFeedback(selectionCopyButton, '<span class="text-red-600">Error</span>');
+                }
+                closeModal(textSelectionModal);
+            });
+        }
+
+        if (selectionAddToJournalButton) {
+            selectionAddToJournalButton.addEventListener('click', () => {
+                openNoteModalForText(currentSelectedText, 'Selected Text', selectionAddToJournalButton);
+                closeModal(textSelectionModal);
+            });
+        }
+
+        if (selectionSearchButton) {
+            selectionSearchButton.addEventListener('click', () => {
+                searchInput.value = currentSelectedText;
+                performSearch();
+                closeModal(textSelectionModal);
+            });
+        }
+
+        if (selectionGoogleSearchButton) {
+            selectionGoogleSearchButton.addEventListener('click', () => {
+                window.open(`https://www.google.com/search?q=${encodeURIComponent(currentSelectedText)}`, '_blank');
+                closeModal(textSelectionModal);
             });
         }


### PR DESCRIPTION
## Summary
- add modal to handle text selection inside scripture cards
- implement logic to show actions for highlighted text
- provide buttons to copy, add to journal, search, or google-search the selection
- clear selection when opening highlight actions so buttons work

## Testing
- `npm test`
